### PR TITLE
fix: Recall will now teleport player to the designated position

### DIFF
--- a/data/pve/function/recall/sethome.mcfunction
+++ b/data/pve/function/recall/sethome.mcfunction
@@ -1,5 +1,5 @@
 # Set home recall postion
-$data modify storage csp29:recall Position set value {x:$(x), y:$(y), z:$(z)}
+$data modify storage pve:recall Position set value {x:$(x), y:$(y), z:$(z)}
 
 $tellraw @a [{text:"[Recall] ",color:"yellow",bold:true},\
 {text:"Set recall home position to $(x) $(y) $(z).",color:"white",bold:false}]


### PR DESCRIPTION
Recall will now teleport the player to the designated position as intended in the next release, 1.1
Resolved #9 