### PR TITLE
Add custom recipes and rebalance smelting mechanics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 spyglass.json
+temp_release_note.txt

--- a/data/pve/advancement/recipes/building/invisible_glow_item_frame.json
+++ b/data/pve/advancement/recipes/building/invisible_glow_item_frame.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_glow_item_frame": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:glow_item_frame"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/invisible_glow_item_frame"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_glow_item_frame",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/invisible_glow_item_frame"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/building/invisible_item_frame.json
+++ b/data/pve/advancement/recipes/building/invisible_item_frame.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_item_frame": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:item_frame"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/invisible_item_frame"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_item_frame",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/invisible_item_frame"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/building/qol/reverse_crafting/reverse_blue_ice.json
+++ b/data/pve/advancement/recipes/building/qol/reverse_crafting/reverse_blue_ice.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_blue_ice": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:blue_ice"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/reverse_crafting/reverse_blue_ice"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_blue_ice",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/reverse_crafting/reverse_blue_ice"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/building/qol/reverse_crafting/reverse_packed_ice.json
+++ b/data/pve/advancement/recipes/building/qol/reverse_crafting/reverse_packed_ice.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_packed_ice": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:packed_ice"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/reverse_crafting/reverse_packed_ice"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_packed_ice",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/reverse_crafting/reverse_packed_ice"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/equipment/copper_shears.json
+++ b/data/pve/advancement/recipes/equipment/copper_shears.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_copper_ingot": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:copper_ingot"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/copper_shears"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_copper_ingot",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/copper_shears"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/equipment/copper_shield.json
+++ b/data/pve/advancement/recipes/equipment/copper_shield.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_copper_ingot": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:copper_ingot"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/copper_shield"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_copper_ingot",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/copper_shield"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/equipment/recall_point_setter/overworld.json
+++ b/data/pve/advancement/recipes/equipment/recall_point_setter/overworld.json
@@ -1,0 +1,42 @@
+{
+    "criteria": {
+        "has_ender_eye": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:ender_eye"
+                    }
+                ]
+            }
+        },
+        "has_amethyst": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:amethyst_shard"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/recall_point_setter/overworld"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_ender_eye",
+            "has_amethyst",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/recall_point_setter/overworld"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/equipment/recall_point_setter/the_end.json
+++ b/data/pve/advancement/recipes/equipment/recall_point_setter/the_end.json
@@ -1,0 +1,42 @@
+{
+    "criteria": {
+        "has_ender_eye": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:ender_eye"
+                    }
+                ]
+            }
+        },
+        "has_end_stone": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:end_stone"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/recall_point_setter/the_end"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_ender_eye",
+            "has_end_stone",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/recall_point_setter/the_end"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/equipment/recall_point_setter/the_nether.json
+++ b/data/pve/advancement/recipes/equipment/recall_point_setter/the_nether.json
@@ -1,0 +1,42 @@
+{
+    "criteria": {
+        "has_ender_eye": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:ender_eye"
+                    }
+                ]
+            }
+        },
+        "has_blaze_rod": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:blaze_rod"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/recall_point_setter/the_nether"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_ender_eye",
+            "has_blaze_rod",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/recall_point_setter/the_nether"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/drinks/black_coffee.json
+++ b/data/pve/advancement/recipes/misc/drinks/black_coffee.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_cocoa_beans": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:cocoa_beans"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/drinks/black_coffee"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_cocoa_beans",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/drinks/black_coffee"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/drinks/dandelion_tea.json
+++ b/data/pve/advancement/recipes/misc/drinks/dandelion_tea.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_dandelion": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:dandelion"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/drinks/dandelion_tea"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_dandelion",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/drinks/dandelion_tea"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/drinks/honey_milk.json
+++ b/data/pve/advancement/recipes/misc/drinks/honey_milk.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_honey_bottle": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:honey_bottle"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/drinks/honey_milk"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_honey_bottle",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/drinks/honey_milk"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/drinks/hot_chocolate.json
+++ b/data/pve/advancement/recipes/misc/drinks/hot_chocolate.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_cocoa_beans": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:cocoa_beans"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/drinks/hot_chocolate"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_cocoa_beans",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/drinks/hot_chocolate"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/lava_chicken.json
+++ b/data/pve/advancement/recipes/misc/lava_chicken.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_lava": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:lava_bucket"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/lava_chicken"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_lava",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/lava_chicken"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/blasting/copper_block_from_blasting_raw_block.json
+++ b/data/pve/advancement/recipes/misc/qol/blasting/copper_block_from_blasting_raw_block.json
@@ -1,0 +1,32 @@
+{
+    "parent": "pve:recipes/root",
+    "criteria": {
+        "has_the_raw_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:raw_copper_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:blasting/qol/copper_block_from_raw_block"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_raw_block",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:blasting/qol/copper_block_from_raw_block"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/blasting/gold_block_from_blasting_raw_block.json
+++ b/data/pve/advancement/recipes/misc/qol/blasting/gold_block_from_blasting_raw_block.json
@@ -1,0 +1,32 @@
+{
+    "parent": "pve:recipes/root",
+    "criteria": {
+        "has_the_raw_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:raw_gold_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:blasting/qol/gold_block_from_raw_block"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_raw_block",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:blasting/qol/gold_block_from_raw_block"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/blasting/iron_block_from_blasting_raw_block.json
+++ b/data/pve/advancement/recipes/misc/qol/blasting/iron_block_from_blasting_raw_block.json
@@ -1,0 +1,32 @@
+{
+    "parent": "pve:recipes/root",
+    "criteria": {
+        "has_the_raw_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:raw_iron_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:blasting/qol/iron_block_from_raw_block"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_raw_block",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:blasting/qol/iron_block_from_raw_block"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/copper_torch.json
+++ b/data/pve/advancement/recipes/misc/qol/copper_torch.json
@@ -1,0 +1,42 @@
+{
+    "criteria": {
+        "has_copper_nugget": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:copper_nugget"
+                    }
+                ]
+            }
+        },
+        "has_torch": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:torch"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/qol/copper_torch"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_copper_nugget",
+            "has_torch",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/qol/copper_torch"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/dyes/black_dyes_from_coals.json
+++ b/data/pve/advancement/recipes/misc/qol/dyes/black_dyes_from_coals.json
@@ -1,0 +1,34 @@
+{
+    "criteria": {
+        "has_coal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": [
+                            "minecraft:coal",
+                            "minecraft:charcoal"
+                        ]
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/dyes/black_dye_from_coals"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_coal",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/dyes/black_dye_from_coals"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/dyes/orange_dye_from_glow_berries.json
+++ b/data/pve/advancement/recipes/misc/qol/dyes/orange_dye_from_glow_berries.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_glow_berries": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:glow_berries"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/dyes/orange_dye_from_glow_berries"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_glow_berries",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/dyes/orange_dye_from_glow_berries"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/dyes/red_dye_from_redstone.json
+++ b/data/pve/advancement/recipes/misc/qol/dyes/red_dye_from_redstone.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_redstone": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:redstone"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/dyes/red_dye_from_redstone"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_redstone",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/dyes/red_dye_from_redstone"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/dyes/red_dye_from_sweet_berries.json
+++ b/data/pve/advancement/recipes/misc/qol/dyes/red_dye_from_sweet_berries.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_sweet_berries": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:sweet_berries"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/dyes/red_dye_from_sweet_berries"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_sweet_berries",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/dyes/red_dye_from_sweet_berries"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/glow_ink_sac_from_glow_berries.json
+++ b/data/pve/advancement/recipes/misc/qol/glow_ink_sac_from_glow_berries.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_glow_berries": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:glow_berries"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/glow_ink_sac_from_glow_berries"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_glow_berries",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/glow_ink_sac_from_glow_berries"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/reverse_crafting/wool_to_string.json
+++ b/data/pve/advancement/recipes/misc/qol/reverse_crafting/wool_to_string.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_wool": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "#minecraft:wool"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/reverse_crafting/wool_to_strings"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_wool",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/reverse_crafting/wool_to_strings"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/rotten_flesh_to_leather.json
+++ b/data/pve/advancement/recipes/misc/qol/rotten_flesh_to_leather.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_rotten_flesh": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:rotten_flesh"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:smoking/qol/rotten_flesh_to_leather"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_rotten_flesh",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:smoking/qol/rotten_flesh_to_leather"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/sticks_from_logs.json
+++ b/data/pve/advancement/recipes/misc/qol/sticks_from_logs.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_logs": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "#minecraft:logs"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shaped/qol/sticks_from_logs"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_logs",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shaped/qol/sticks_from_logs"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/two_by_two_able/bread_2x2.json
+++ b/data/pve/advancement/recipes/misc/qol/two_by_two_able/bread_2x2.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_wheat": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:wheat"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/two_by_two_able/bread_2x2"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_wheat",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/two_by_two_able/bread_2x2"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/misc/qol/two_by_two_able/paper_2x2.json
+++ b/data/pve/advancement/recipes/misc/qol/two_by_two_able/paper_2x2.json
@@ -1,0 +1,31 @@
+{
+    "criteria": {
+        "has_sugar_cane": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "minecraft:sugar_cane"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "pve:shapeless/qol/two_by_two_able/paper_2x2"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_sugar_cane",
+            "has_the_recipe"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "pve:shapeless/qol/two_by_two_able/paper_2x2"
+        ]
+    }
+}

--- a/data/pve/advancement/recipes/root.json
+++ b/data/pve/advancement/recipes/root.json
@@ -1,0 +1,12 @@
+{
+    "criteria": {
+        "impossible": {
+            "trigger": "minecraft:impossible"
+        }
+    },
+    "requirements": [
+        [
+            "impossible"
+        ]
+    ]
+}

--- a/data/pve/recipe/blasting/qol/copper_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/copper_block_from_raw_block.json
@@ -1,9 +1,10 @@
 {
-    "type": "minecraft:blasting",
-    "ingredient": "minecraft:raw_copper_block",
-    "result": {
-      "id": "minecraft:copper_block"
-    },
-    "experience": 7.0,
-    "cookingtime": 900
+  "type": "minecraft:blasting",
+  "category": "misc",
+  "ingredient": "minecraft:raw_copper_block",
+  "result": {
+    "id": "minecraft:copper_block"
+  },
+  "experience": 7.0,
+  "cookingtime": 900
 }

--- a/data/pve/recipe/blasting/qol/copper_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/copper_block_from_raw_block.json
@@ -4,6 +4,6 @@
     "result": {
       "id": "minecraft:copper_block"
     },
-    "experience": 0.1,
-    "cookingtime": 100
+    "experience": 7.0,
+    "cookingtime": 900
 }

--- a/data/pve/recipe/blasting/qol/gold_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/gold_block_from_raw_block.json
@@ -1,9 +1,10 @@
 {
-    "type": "minecraft:blasting",
-    "ingredient": "minecraft:raw_gold_block",
-    "result": {
-      "id": "minecraft:gold_block"
-    },
-    "experience": 7.0,
-    "cookingtime": 900
+  "type": "minecraft:blasting",
+  "category": "misc",
+  "ingredient": "minecraft:raw_gold_block",
+  "result": {
+    "id": "minecraft:gold_block"
+  },
+  "experience": 7.0,
+  "cookingtime": 900
 }

--- a/data/pve/recipe/blasting/qol/gold_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/gold_block_from_raw_block.json
@@ -4,6 +4,6 @@
     "result": {
       "id": "minecraft:gold_block"
     },
-    "experience": 0.1,
-    "cookingtime": 100
+    "experience": 7.0,
+    "cookingtime": 900
 }

--- a/data/pve/recipe/blasting/qol/iron_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/iron_block_from_raw_block.json
@@ -1,5 +1,6 @@
 {
   "type": "minecraft:blasting",
+  "category": "misc",
   "ingredient": "minecraft:raw_iron_block",
   "result": {
     "id": "minecraft:iron_block"

--- a/data/pve/recipe/blasting/qol/iron_block_from_raw_block.json
+++ b/data/pve/recipe/blasting/qol/iron_block_from_raw_block.json
@@ -1,9 +1,9 @@
 {
-    "type": "minecraft:blasting",
-    "ingredient": "minecraft:raw_iron_block",
-    "result": {
-      "id": "minecraft:iron_block"
-    },
-    "experience": 0.1,
-    "cookingtime": 100
+  "type": "minecraft:blasting",
+  "ingredient": "minecraft:raw_iron_block",
+  "result": {
+    "id": "minecraft:iron_block"
+  },
+  "experience": 7.0,
+  "cookingtime": 900
 }

--- a/data/pve/recipe/shaped/lava_chicken.json
+++ b/data/pve/recipe/shaped/lava_chicken.json
@@ -1,5 +1,6 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "misc",
   "pattern": [
     "CCC",
     "CLC",

--- a/data/pve/recipe/shaped/qol/copper_torch.json
+++ b/data/pve/recipe/shaped/qol/copper_torch.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "misc",
     "pattern": [
         "#",
         "T"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/acacia_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/acacia_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/andesite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/andesite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/bamboo_mosaic_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/bamboo_mosaic_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/bamboo_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/bamboo_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/birch_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/birch_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/blackstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/blackstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cherry_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cherry_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cinnabar_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cinnabar_brick_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:cinnabar_brick_stairs"
+    },
+    "result": {
+        "id": "minecraft:cinnabar_bricks",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cinnabar_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cinnabar_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:cinnabar_stairs"
+    },
+    "result": {
+        "id": "minecraft:cinnabar",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cobbled_deepslate_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cobbled_deepslate_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cobblestone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cobblestone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/crimson_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/crimson_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/dark_oak_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/dark_oak_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/dark_prismarine_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/dark_prismarine_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/deepslate_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/deepslate_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/deepslate_tiles_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/deepslate_tiles_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/diorite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/diorite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/end_stone_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/end_stone_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/exposed_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/exposed_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/granite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/granite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/jungle_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/jungle_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/mangrove_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/mangrove_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/mossy_cobblestone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/mossy_cobblestone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/mossy_stone_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/mossy_stone_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/mud_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/mud_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/nether_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/nether_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/oak_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/oak_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/oxidized_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/oxidized_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/pale_oak_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/pale_oak_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_andesite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_andesite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_blackstone_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_blackstone_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_blackstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_blackstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_cinnabar_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_cinnabar_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:polished_cinnabar_stairs"
+    },
+    "result": {
+        "id": "minecraft:polished_cinnabar",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_deepslate_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_deepslate_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_diorite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_diorite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_granite_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_granite_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_sulfur_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_sulfur_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:polished_sulfur_stairs"
+    },
+    "result": {
+        "id": "minecraft:polished_sulfur",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/polished_tuff_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/polished_tuff_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/prismarine_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/prismarine_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/prismarine_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/prismarine_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/purpur_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/purpur_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/quartz_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/quartz_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/red_nether_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/red_nether_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/red_sandstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/red_sandstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/resin_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/resin_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/sandstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/sandstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/smooth_quartz_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/smooth_quartz_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/smooth_red_sandstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/smooth_red_sandstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/smooth_sandstone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/smooth_sandstone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/spruce_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/spruce_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/stone_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/stone_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/stone_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/stone_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/sulfur_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/sulfur_brick_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:sulfur_brick_stairs"
+    },
+    "result": {
+        "id": "minecraft:sulfur_bricks",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/sulfur_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/sulfur_stairs.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": "minecraft:sulfur_stairs"
+    },
+    "result": {
+        "id": "minecraft:sulfur",
+        "count": 3
+    }
+}

--- a/data/pve/recipe/shaped/qol/stairs_to_block/tuff_brick_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/tuff_brick_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/tuff_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/tuff_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/warped_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/warped_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/waxed_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/waxed_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/waxed_exposed_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/waxed_exposed_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/waxed_oxidized_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/waxed_oxidized_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/waxed_weathered_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/waxed_weathered_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/stairs_to_block/weathered_cut_copper_stairs.json
+++ b/data/pve/recipe/shaped/qol/stairs_to_block/weathered_cut_copper_stairs.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "building",
     "pattern": [
         "##",
         "##"

--- a/data/pve/recipe/shaped/qol/sticks_from_logs.json
+++ b/data/pve/recipe/shaped/qol/sticks_from_logs.json
@@ -1,5 +1,7 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "group": "sticks",
     "key": {
         "a": "#minecraft:logs"
     },

--- a/data/pve/recipe/shaped/recall_point_setter/overworld.json
+++ b/data/pve/recipe/shaped/recall_point_setter/overworld.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "equipment",
     "pattern": [
         " m ",
         "aea",

--- a/data/pve/recipe/shaped/recall_point_setter/the_end.json
+++ b/data/pve/recipe/shaped/recall_point_setter/the_end.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "equipment",
     "pattern": [
         " b ",
         "oeo",

--- a/data/pve/recipe/shaped/recall_point_setter/the_nether.json
+++ b/data/pve/recipe/shaped/recall_point_setter/the_nether.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "equipment",
     "pattern": [
         " b ",
         "geg",

--- a/data/pve/recipe/shapeless/drinks/black_coffee.json
+++ b/data/pve/recipe/shapeless/drinks/black_coffee.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glass_bottle",
         "minecraft:cocoa_beans",

--- a/data/pve/recipe/shapeless/drinks/dandelion_tea.json
+++ b/data/pve/recipe/shapeless/drinks/dandelion_tea.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glass_bottle",
         "minecraft:dandelion",

--- a/data/pve/recipe/shapeless/drinks/honey_milk.json
+++ b/data/pve/recipe/shapeless/drinks/honey_milk.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glass_bottle",
         "minecraft:milk_bucket",

--- a/data/pve/recipe/shapeless/drinks/hot_chocolate.json
+++ b/data/pve/recipe/shapeless/drinks/hot_chocolate.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glass_bottle",
         "minecraft:cocoa_beans",

--- a/data/pve/recipe/shapeless/invisible_glow_item_frame.json
+++ b/data/pve/recipe/shapeless/invisible_glow_item_frame.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:glow_item_frame",
         "#pve:glass_panes"

--- a/data/pve/recipe/shapeless/invisible_item_frame.json
+++ b/data/pve/recipe/shapeless/invisible_item_frame.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:item_frame",
         "#pve:glass_panes"

--- a/data/pve/recipe/shapeless/qol/dyes/black_dye_from_coals.json
+++ b/data/pve/recipe/shapeless/qol/dyes/black_dye_from_coals.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         [
             "minecraft:coal",

--- a/data/pve/recipe/shapeless/qol/dyes/orange_dye_from_glow_berries.json
+++ b/data/pve/recipe/shapeless/qol/dyes/orange_dye_from_glow_berries.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glow_berries"
     ],

--- a/data/pve/recipe/shapeless/qol/dyes/red_dye_from_redstone.json
+++ b/data/pve/recipe/shapeless/qol/dyes/red_dye_from_redstone.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:redstone"
     ],

--- a/data/pve/recipe/shapeless/qol/dyes/red_dye_from_sweet_berries.json
+++ b/data/pve/recipe/shapeless/qol/dyes/red_dye_from_sweet_berries.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:sweet_berries"
     ],

--- a/data/pve/recipe/shapeless/qol/glow_ink_sac_from_glow_berries.json
+++ b/data/pve/recipe/shapeless/qol/glow_ink_sac_from_glow_berries.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "minecraft:glow_berries",
         "minecraft:glow_berries",

--- a/data/pve/recipe/shapeless/qol/reverse_crafting/reverse_blue_ice.json
+++ b/data/pve/recipe/shapeless/qol/reverse_crafting/reverse_blue_ice.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:blue_ice"
     ],

--- a/data/pve/recipe/shapeless/qol/reverse_crafting/reverse_packed_ice.json
+++ b/data/pve/recipe/shapeless/qol/reverse_crafting/reverse_packed_ice.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:packed_ice"
     ],

--- a/data/pve/recipe/shapeless/qol/reverse_crafting/wool_to_strings.json
+++ b/data/pve/recipe/shapeless/qol/reverse_crafting/wool_to_strings.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
         "#minecraft:wool"
     ],

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/acacia_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/acacia_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:acacia_slab",
         "minecraft:acacia_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/andesite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/andesite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:andesite_slab",
         "minecraft:andesite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/bamboo_mosaic_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/bamboo_mosaic_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:bamboo_mosaic_slab",
         "minecraft:bamboo_mosaic_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/bamboo_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/bamboo_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:bamboo_slab",
         "minecraft:bamboo_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/birch_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/birch_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:birch_slab",
         "minecraft:birch_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/blackstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/blackstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:blackstone_slab",
         "minecraft:blackstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:brick_slab",
         "minecraft:brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cherry_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cherry_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cherry_slab",
         "minecraft:cherry_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cinnabar_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cinnabar_brick_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:cinnabar_brick_slab",
+        "minecraft:cinnabar_brick_slab"
+    ],
+    "result": {
+        "id": "minecraft:cinnabar_bricks",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cinnabar_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cinnabar_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:cinnabar_slab",
+        "minecraft:cinnabar_slab"
+    ],
+    "result": {
+        "id": "minecraft:cinnabar",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cobbled_deepslate_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cobbled_deepslate_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cobbled_deepslate_slab",
         "minecraft:cobbled_deepslate_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cobblestone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cobblestone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cobblestone_slab",
         "minecraft:cobblestone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/crimson_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/crimson_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:crimson_slab",
         "minecraft:crimson_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cut_copper_slab",
         "minecraft:cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cut_red_sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cut_red_sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cut_red_sandstone_slab",
         "minecraft:cut_red_sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/cut_sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/cut_sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:cut_sandstone_slab",
         "minecraft:cut_sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/dark_oak_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/dark_oak_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:dark_oak_slab",
         "minecraft:dark_oak_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/dark_prismarine_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/dark_prismarine_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:dark_prismarine_slab",
         "minecraft:dark_prismarine_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/deepslate_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/deepslate_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:deepslate_brick_slab",
         "minecraft:deepslate_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/deepslate_tile_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/deepslate_tile_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:deepslate_tile_slab",
         "minecraft:deepslate_tile_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/diorite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/diorite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:diorite_slab",
         "minecraft:diorite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/end_stone_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/end_stone_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:end_stone_brick_slab",
         "minecraft:end_stone_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/exposed_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/exposed_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:exposed_cut_copper_slab",
         "minecraft:exposed_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/granite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/granite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:granite_slab",
         "minecraft:granite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/jungle_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/jungle_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:jungle_slab",
         "minecraft:jungle_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/mangrove_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/mangrove_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:mangrove_slab",
         "minecraft:mangrove_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/mossy_cobblestone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/mossy_cobblestone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:mossy_cobblestone_slab",
         "minecraft:mossy_cobblestone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/mossy_stone_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/mossy_stone_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:mossy_stone_brick_slab",
         "minecraft:mossy_stone_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/mud_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/mud_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:mud_brick_slab",
         "minecraft:mud_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/nether_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/nether_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:nether_brick_slab",
         "minecraft:nether_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/oak_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/oak_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:oak_slab",
         "minecraft:oak_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/oxidized_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/oxidized_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:oxidized_cut_copper_slab",
         "minecraft:oxidized_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/pale_oak_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/pale_oak_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:pale_oak_slab",
         "minecraft:pale_oak_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_andesite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_andesite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_andesite_slab",
         "minecraft:polished_andesite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_blackstone_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_blackstone_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_blackstone_brick_slab",
         "minecraft:polished_blackstone_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_blackstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_blackstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_blackstone_slab",
         "minecraft:polished_blackstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_cinnabar_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_cinnabar_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:polished_cinnabar_slab",
+        "minecraft:polished_cinnabar_slab"
+    ],
+    "result": {
+        "id": "minecraft:polished_cinnabar",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_deepslate_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_deepslate_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_deepslate_slab",
         "minecraft:polished_deepslate_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_diorite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_diorite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_diorite_slab",
         "minecraft:polished_diorite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_granite_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_granite_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_granite_slab",
         "minecraft:polished_granite_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_sulfur_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_sulfur_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:polished_sulfur_slab",
+        "minecraft:polished_sulfur_slab"
+    ],
+    "result": {
+        "id": "minecraft:polished_sulfur",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/polished_tuff_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/polished_tuff_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:polished_tuff_slab",
         "minecraft:polished_tuff_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/prismarine_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/prismarine_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:prismarine_brick_slab",
         "minecraft:prismarine_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/prismarine_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/prismarine_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:prismarine_slab",
         "minecraft:prismarine_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/purpur_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/purpur_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:purpur_slab",
         "minecraft:purpur_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/quartz_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/quartz_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:quartz_slab",
         "minecraft:quartz_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/red_nether_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/red_nether_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:red_nether_brick_slab",
         "minecraft:red_nether_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/red_sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/red_sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:red_sandstone_slab",
         "minecraft:red_sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/resin_bricks_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/resin_bricks_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:resin_brick_slab",
         "minecraft:resin_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:sandstone_slab",
         "minecraft:sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_quartz_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_quartz_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:smooth_quartz_slab",
         "minecraft:smooth_quartz_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_red_sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_red_sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:smooth_red_sandstone_slab",
         "minecraft:smooth_red_sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_sandstone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_sandstone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:smooth_sandstone_slab",
         "minecraft:smooth_sandstone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_stone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/smooth_stone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:smooth_stone_slab",
         "minecraft:smooth_stone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/spruce_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/spruce_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:spruce_slab",
         "minecraft:spruce_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/stone_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/stone_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:stone_brick_slab",
         "minecraft:stone_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/stone_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/stone_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:stone_slab",
         "minecraft:stone_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/sulfur_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/sulfur_brick_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:sulfur_brick_slab",
+        "minecraft:sulfur_brick_slab"
+    ],
+    "result": {
+        "id": "minecraft:sulfur_bricks",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/sulfur_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/sulfur_slab.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        "minecraft:sulfur_slab",
+        "minecraft:sulfur_slab"
+    ],
+    "result": {
+        "id": "minecraft:sulfur",
+        "count": 1
+    }
+}

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/tuff_brick_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/tuff_brick_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:tuff_brick_slab",
         "minecraft:tuff_brick_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/tuff_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/tuff_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:tuff_slab",
         "minecraft:tuff_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/warped_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/warped_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:warped_slab",
         "minecraft:warped_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:waxed_cut_copper_slab",
         "minecraft:waxed_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_exposed_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_exposed_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:waxed_exposed_cut_copper_slab",
         "minecraft:waxed_exposed_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_oxidized_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_oxidized_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:waxed_oxidized_cut_copper_slab",
         "minecraft:waxed_oxidized_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_weathered_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/waxed_weathered_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:waxed_weathered_cut_copper_slab",
         "minecraft:waxed_weathered_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/slabs_to_block/weathered_cut_copper_slab.json
+++ b/data/pve/recipe/shapeless/qol/slabs_to_block/weathered_cut_copper_slab.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "building",
     "ingredients": [
         "minecraft:weathered_cut_copper_slab",
         "minecraft:weathered_cut_copper_slab"

--- a/data/pve/recipe/shapeless/qol/two_by_two_able/bread_2x2.json
+++ b/data/pve/recipe/shapeless/qol/two_by_two_able/bread_2x2.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
       "minecraft:wheat",
       "minecraft:wheat",

--- a/data/pve/recipe/shapeless/qol/two_by_two_able/paper_2x2.json
+++ b/data/pve/recipe/shapeless/qol/two_by_two_able/paper_2x2.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shapeless",
+    "category": "misc",
     "ingredients": [
       "minecraft:sugar_cane",
       "minecraft:sugar_cane",

--- a/data/pve/recipe/smelting/qol/copper_block_from_raw_block.json
+++ b/data/pve/recipe/smelting/qol/copper_block_from_raw_block.json
@@ -1,9 +1,0 @@
-{
-    "type": "minecraft:smelting",
-    "ingredient": "minecraft:raw_copper_block",
-    "result": {
-      "id": "minecraft:copper_block"
-    },
-    "experience": 0.1,
-    "cookingtime": 100
-}

--- a/data/pve/recipe/smelting/qol/gold_block_from_raw_block.json
+++ b/data/pve/recipe/smelting/qol/gold_block_from_raw_block.json
@@ -1,9 +1,0 @@
-{
-    "type": "minecraft:smelting",
-    "ingredient": "minecraft:raw_gold_block",
-    "result": {
-      "id": "minecraft:gold_block"
-    },
-    "experience": 0.1,
-    "cookingtime": 100
-}

--- a/data/pve/recipe/smelting/qol/iron_block_from_raw_block.json
+++ b/data/pve/recipe/smelting/qol/iron_block_from_raw_block.json
@@ -1,9 +1,0 @@
-{
-    "type": "minecraft:smelting",
-    "ingredient": "minecraft:raw_iron_block",
-    "result": {
-      "id": "minecraft:iron_block"
-    },
-    "experience": 0.1,
-    "cookingtime": 100
-}

--- a/data/pve/recipe/smoking/qol/rotten_flesh_to_leather.json
+++ b/data/pve/recipe/smoking/qol/rotten_flesh_to_leather.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:smoking",
+    "category": "misc",
     "ingredient": "minecraft:rotten_flesh",
     "result": {
       "id": "minecraft:leather"

--- a/data/pve/recipe/smoking/qol/rotten_flesh_to_leather.json
+++ b/data/pve/recipe/smoking/qol/rotten_flesh_to_leather.json
@@ -4,6 +4,6 @@
     "result": {
       "id": "minecraft:leather"
     },
-    "experience": 0.1,
+    "experience": 0.35,
     "cookingtime": 100
 }


### PR DESCRIPTION
Introduce root advancements for custom recipes, categorize 145 recipes, and adjust experience points for specific actions. Enhance the smelting process for raw ore blocks and add new crafting categories for various items. Update the .gitignore file to include temporary release notes.