### PR TITLE
Add more farmer and weaponsmith trades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 spyglass.json
-temp_release_note.txt
+temp_release_note.md

--- a/data/minecraft/tags/villager_trade/common_smith/level_1.json
+++ b/data/minecraft/tags/villager_trade/common_smith/level_1.json
@@ -1,6 +1,6 @@
 {
     "values": [
-        "pve:smith/level_1/copper_ingot_emerald",
-        "pve:smith/level_1/amethyst_shard_emerald"
+        "pve:common_smith/level_1/copper_ingot_emerald",
+        "pve:common_smith/level_1/amethyst_shard_emerald"
     ]
 }

--- a/data/minecraft/tags/villager_trade/farmer/level_3.json
+++ b/data/minecraft/tags/villager_trade/farmer/level_3.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "pve:farmer/level_3/dandelion_and_emeralds_golden_dandelion",
         "pve:farmer/level_3/kelp_emerald"
     ]
 }

--- a/data/minecraft/tags/villager_trade/farmer/level_5.json
+++ b/data/minecraft/tags/villager_trade/farmer/level_5.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "pve:farmer/level_5/chorus_fruits_emerald",
         "#pve:farmer/level_5_froglights"
     ]
 }

--- a/data/minecraft/tags/villager_trade/weaponsmith/level_1.json
+++ b/data/minecraft/tags/villager_trade/weaponsmith/level_1.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "pve:weaponsmith/level_1/bones_emerald"
+    ]
+}

--- a/data/pve/villager_trade/common_smith/level_1/amethyst_shard_emerald.json
+++ b/data/pve/villager_trade/common_smith/level_1/amethyst_shard_emerald.json
@@ -1,7 +1,11 @@
 {
     "wants": {
         "id": "minecraft:amethyst_shard",
-        "count": 16
+        "count": {
+            "type": "minecraft:uniform",
+            "min": 12,
+            "max": 16
+        }
     },
     "max_uses": 16,
     "reputation_discount": 0.05,

--- a/data/pve/villager_trade/common_smith/level_1/copper_ingot_emerald.json
+++ b/data/pve/villager_trade/common_smith/level_1/copper_ingot_emerald.json
@@ -1,7 +1,11 @@
 {
     "wants": {
         "id": "minecraft:copper_ingot",
-        "count": 12
+        "count": {
+            "type": "minecraft:uniform",
+            "min": 10,
+            "max": 12
+        }
     },
     "max_uses": 16,
     "reputation_discount": 0.05,

--- a/data/pve/villager_trade/farmer/level_3/dandelion_and_emeralds_golden_dandelion.json
+++ b/data/pve/villager_trade/farmer/level_3/dandelion_and_emeralds_golden_dandelion.json
@@ -1,0 +1,17 @@
+{
+    "wants": {
+        "id": "minecraft:dandelion",
+        "count": 1
+    },
+    "additional_wants": {
+        "id": "minecraft:emerald",
+        "count": 2
+    },
+    "max_uses": 12,
+    "reputation_discount": 0.05,
+    "gives": {
+        "id": "minecraft:golden_dandelion",
+        "count": 1
+    },
+    "xp": 15
+}

--- a/data/pve/villager_trade/farmer/level_5/chorus_fruits_emerald.json
+++ b/data/pve/villager_trade/farmer/level_5/chorus_fruits_emerald.json
@@ -1,0 +1,17 @@
+{
+    "wants": {
+        "id": "minecraft:chorus_fruit",
+        "count": {
+            "type": "minecraft:uniform",
+            "min": 9,
+            "max": 12
+        }
+    },
+    "max_uses": 16,
+    "reputation_discount": 0.05,
+    "gives": {
+        "id": "minecraft:emerald",
+        "count": 1
+    },
+    "xp": 30
+}

--- a/data/pve/villager_trade/weaponsmith/level_1/bones_emerald.json
+++ b/data/pve/villager_trade/weaponsmith/level_1/bones_emerald.json
@@ -1,0 +1,17 @@
+{
+    "wants": {
+        "id": "minecraft:bone",
+        "count": {
+            "type": "minecraft:uniform",
+            "min": 6,
+            "max": 7
+        }
+    },
+    "max_uses": 12,
+    "reputation_discount": 0.05,
+    "gives": {
+        "id": "minecraft:emerald",
+        "count": 1
+    },
+    "xp": 2
+}


### PR DESCRIPTION
Enhance the trading options for farmers and weaponsmiths by adding new trades and adjusting existing ones. Update common smith trades to reflect the correct category and modify item counts for better balance.